### PR TITLE
add PLOOC header files

### DIFF
--- a/make-libmqttclient.sh
+++ b/make-libmqttclient.sh
@@ -65,6 +65,7 @@ cp -r ../common/*.h include/.
 cp -r ../network/*.h include/.
 cp -r ../mqttclient/*.h include/.
 cp -r ../common/log/*.h include/.
+cp -r ../common/PLOOC/*.h include/.
 cp -r ../platform/linux/*.h include/.
 cp -r ../network/mbedtls/include/mbedtls include/.
 cp -r ../network/mbedtls/wrapper/*.h include/.


### PR DESCRIPTION
this will fix include errors:
../mqttclient/mqttclient.h:39:10: fatal error: plooc_class.h: No such file or directory
 #include "plooc_class.h"
          ^~~~~~~~~~~~~~~
compilation terminated.