### PR TITLE
Update plooc.h

### DIFF
--- a/common/PLOOC/plooc.h
+++ b/common/PLOOC/plooc.h
@@ -14,7 +14,10 @@
  *  limitations under the License.                                           *
  *                                                                           *
  ****************************************************************************/
-
+typedef enum {
+     false, 
+     true
+} bool;
 #ifndef __PROTECTED_LOW_OVERHEAD_OBJECT_ORIENTED_C_H__
 #define __PROTECTED_LOW_OVERHEAD_OBJECT_ORIENTED_C_H__
 


### PR DESCRIPTION
修复OpenWrt交叉编译报错
```
arm-openwrt-linux-gcc -c -g -fpic -I. -Iinclude -lpthread -I../common -I../common/log -I../network/mbedtls/include -I../network/mbedtls/include/mbedtls -I../network/mbedtls/wrapper -I../mqtt -I../mqttclient -I../network -I../platform/linux -I../test  ../mqttclient/mqttclient.c -o ../mqttclient/mqttclient.o
In file included from ../mqttclient/mqttclient.h:39:0,
                 from ../mqttclient/mqttclient.c:10:
include/plooc_class.h:47:5: warning: #warning For C89/90, __OOC_DEBUG__ is enforced. [-Wcpp]
 #   warning For C89/90, __OOC_DEBUG__ is enforced. 
     ^
In file included from include/plooc_class.h:94:0,
                 from ../mqttclient/mqttclient.h:39,
                 from ../mqttclient/mqttclient.c:10:
include/./plooc.h:263:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(uint32_t wValue);
     ^
include/./plooc.h:272:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(uint_fast16_t wValue);
     ^
include/./plooc.h:281:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(uint_fast8_t wValue);
     ^
include/./plooc.h:291:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(int32_t wValue);
     ^
include/./plooc.h:300:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(int_fast16_t wValue);
     ^
include/./plooc.h:309:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(int_fast8_t wValue);
     ^
include/./plooc.h:318:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Set)(bool bValue);
     ^
include/./plooc.h:327:5: error: expected specifier-qualifier-list before 'bool'
     bool (*Enable)(void);
     ^
Makefile:37: recipe for target '../mqttclient/mqttclient.o' failed
make: *** [../mqttclient/mqttclient.o] Error 1

```