### PR TITLE
Use GNU99 when cross compile

### DIFF
--- a/common/PLOOC/plooc.h
+++ b/common/PLOOC/plooc.h
@@ -14,10 +14,7 @@
  *  limitations under the License.                                           *
  *                                                                           *
  ****************************************************************************/
-typedef enum {
-     false, 
-     true
-} bool;
+
 #ifndef __PROTECTED_LOW_OVERHEAD_OBJECT_ORIENTED_C_H__
 #define __PROTECTED_LOW_OVERHEAD_OBJECT_ORIENTED_C_H__
 

--- a/make-libmqttclient.sh
+++ b/make-libmqttclient.sh
@@ -35,7 +35,7 @@ INC =   -lpthread \\
 
 OBJS = \$(patsubst %.c, %.o, \$(SRC))
 
-FLAG = -g -fpic -I. -Iinclude \$(INC) 
+FLAG = -g -fpic -std=gnu99 -I. -Iinclude \$(INC) 
 TARGET = libmqttclient.so
 
 EOF


### PR DESCRIPTION
不好意思，更改plooc.h显得太过于粗暴，使用gnu99即可解决交叉编译问题。
另外，我认为当$(CROSS_COMPILE)存在时，
```
install:
	sudo cp -rdf $(TARGET) /usr/lib/.

remove:
	sudo rm -rdf /usr/lib/$(TARGET)
```
就不应该再安装到宿主机了。不知您的看法呢？