### PR TITLE
Fix memory leak when mqtt_yield_thread exits problem and delete unuse…

### DIFF
--- a/mqttclient/mqttclient.c
+++ b/mqttclient/mqttclient.c
@@ -954,8 +954,12 @@ static void mqtt_yield_thread(void *arg)
     
 exit:
     thread_to_be_destoried = c->mqtt_thread;
-    c->mqtt_thread = (platform_thread_t *)0;
-    platform_thread_destroy(thread_to_be_destoried);
+    if(NULL != thread_to_be_destoried)
+    {
+        platform_thread_destroy(thread_to_be_destoried);
+        platform_memory_free(thread_to_be_destoried);
+        thread_to_be_destoried = NULL;
+    }
 }
 
 static int mqtt_connect_with_results(mqtt_client_t* c)
@@ -1457,7 +1461,6 @@ exit:
 
 int mqtt_list_subscribe_topic(mqtt_client_t* c)
 {
-    int i = 0;
     mqtt_list_t *curr, *next;
     message_handlers_t *msg_handler;
     


### PR DESCRIPTION
1、关于static void mqtt_yield_thread(void *arg)函数内存泄漏问题
当内部线程退出时并没有真正释放里面的内存，这是因为platform_thread_init里面的malloc并没有被释放掉，因此当调用mqtt_release接口时会有1个内存泄漏。
2、int mqtt_list_subscribe_topic(mqtt_client_t* c)
该函数中有一个未被使用的变量i在编译时会产生警告，已去除。