### PR TITLE
fix: fix memory leak during network disconnect

### DIFF
--- a/network/network.c
+++ b/network/network.c
@@ -73,9 +73,10 @@ int network_init(network_t *n, const char *host, const char *port, const char *c
 void network_release(network_t* n)
 {
     if (n->socket >= 0)
+    {
         network_disconnect(n);
-
-    memset(n, 0, sizeof(network_t));
+        memset(n, 0, sizeof(network_t));
+    }
 }
 
 void network_set_channel(network_t *n, int channel)


### PR DESCRIPTION
断网期间，n->socket无效，导致network内存资源一直无法释放，一旦重连又会申请新的network资源，所以每次断网都会产生一次内存泄漏。