### PR TITLE
platform:fix possible double free for FreeRTOS

### DIFF
--- a/mqttclient/mqttclient.c
+++ b/mqttclient/mqttclient.c
@@ -957,7 +957,6 @@ exit:
     if(NULL != thread_to_be_destoried)
     {
         platform_thread_destroy(thread_to_be_destoried);
-        platform_memory_free(thread_to_be_destoried);
         thread_to_be_destoried = NULL;
     }
 }

--- a/platform/FreeRTOS/platform_thread.c
+++ b/platform/FreeRTOS/platform_thread.c
@@ -17,7 +17,7 @@ platform_thread_t *platform_thread_init( const char *name,
 {
     BaseType_t err;
     platform_thread_t *thread;
-    
+
     thread = platform_memory_alloc(sizeof(platform_thread_t));
 
     (void)tick;
@@ -50,10 +50,11 @@ void platform_thread_start(platform_thread_t* thread)
 
 void platform_thread_destroy(platform_thread_t* thread)
 {
-    if (NULL != thread)
-        vTaskDelete(thread->thread);
-    
-    platform_memory_free(thread);
+    if (NULL != thread) {
+        TaskHandle_t thread_handle = thread->thread;
+
+        platform_memory_free(thread);
+
+        vTaskDelete(thread_handle);
+    }
 }
-
-

--- a/platform/RT-Thread/platform_thread.c
+++ b/platform/RT-Thread/platform_thread.c
@@ -28,14 +28,14 @@ platform_thread_t *platform_thread_init( const char *name,
     thread->thread = rt_thread_create((const char *)name,
         entry, param,
         stack_size, priority, tick);
-    
+
     if (thread->thread == RT_NULL)
     {
-        return RT_NULL;    
+        return RT_NULL;
     }
     else
     {
-        return thread;    
+        return thread;
     }
 
 }
@@ -49,7 +49,6 @@ void platform_thread_startup(platform_thread_t* thread)
 void platform_thread_stop(platform_thread_t* thread)
 {
     rt_thread_suspend(thread->thread);
-    
 }
 
 void platform_thread_start(platform_thread_t* thread)
@@ -59,8 +58,9 @@ void platform_thread_start(platform_thread_t* thread)
 
 void platform_thread_destroy(platform_thread_t* thread)
 {
-    rt_thread_delete(thread->thread);
-    platform_memory_free(thread);
+    if (thread) {
+        rt_thread_t thread_handle = thread->thread;
+        platform_memory_free(thread);
+        rt_thread_delete(thread_handle);
+    }
 }
-
-

--- a/platform/RT-Thread/platform_thread.c
+++ b/platform/RT-Thread/platform_thread.c
@@ -59,6 +59,7 @@ void platform_thread_start(platform_thread_t* thread)
 
 void platform_thread_destroy(platform_thread_t* thread)
 {
+    rt_thread_delete(thread->thread);
     platform_memory_free(thread);
 }
 

--- a/platform/TencentOS-tiny/platform_thread.c
+++ b/platform/TencentOS-tiny/platform_thread.c
@@ -59,8 +59,8 @@ void platform_thread_destroy(platform_thread_t* thread)
 {
     if (NULL != thread)
         tos_task_destroy(&(thread->thread));
+    platform_memory_free(thread->thread.stk_base);
     platform_memory_free(&(thread->thread));
-    platform_memory_free(&(thread->thread.stk_size));
 }
 
 

--- a/platform/linux/platform_thread.c
+++ b/platform/linux/platform_thread.c
@@ -54,8 +54,10 @@ void platform_thread_start(platform_thread_t* thread)
 
 void platform_thread_destroy(platform_thread_t* thread)
 {
-    if (NULL != thread)
+    if (NULL != thread) {
         pthread_detach(thread->thread);
+        platform_memory_free(thread);
+    }
 }
 
 


### PR DESCRIPTION
FreeRTOS implementation of platform_thread_destroy free the pointer passed to the function and later the same pointer is freed again at [mqttclient/mqttclient.c#L959](https://github.com/jiejieTop/mqttclient/blob/956e0c8dcac02d4b107ccb49f1990c7718b6b585/mqttclient/mqttclient.c#L959)

This will cause possible double free for FreeRTOS implementation.